### PR TITLE
Allow fake players to be given stages. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ run/
 .project
 .settings/
 /bin/
+/.idea/

--- a/src/main/java/net/darkhax/gamestages/FakePlayerData.java
+++ b/src/main/java/net/darkhax/gamestages/FakePlayerData.java
@@ -1,0 +1,110 @@
+package net.darkhax.gamestages;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Sets;
+import com.google.common.io.Files;
+import com.google.gson.Gson;
+import net.darkhax.gamestages.capabilities.PlayerDataHandler;
+import net.minecraft.entity.player.EntityPlayer;
+import org.apache.logging.log4j.Level;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.FileNotFoundException;
+import java.util.*;
+
+public class FakePlayerData implements PlayerDataHandler.IStageData {
+    private static final Map<String, FakePlayerData> fakePlayerData = new HashMap<>();
+    public static void reloadFromFile() {
+        GameStages.LOG.getLogger().log(Level.INFO, "Clearing gamestages fakeplayers for reload");
+        fakePlayerData.clear();
+        if (!GameStages.fakePlayerDataFile.exists()) return;
+        Gson gson = new Gson();
+
+        try {
+            final FakePlayerData[] fakePlayers = gson.fromJson(Files.newReader(GameStages.fakePlayerDataFile, Charsets.UTF_8), FakePlayerData[].class);
+            Arrays.stream(fakePlayers).forEach(FakePlayerData::addFakePlayer);
+        } catch (FileNotFoundException e) {
+            // how did this happen?
+        }
+    }
+
+    public static void addFakePlayer(final String fakePlayerName, final Set<String> stages) {
+        fakePlayerData.put(fakePlayerName, new FakePlayerData(fakePlayerName, stages));
+    }
+
+    public static void addFakePlayer(final FakePlayerData data) {
+        fakePlayerData.put(data.fakePlayerName, data);
+        GameStages.LOG.getLogger().log(Level.INFO, "Adding fakeplayer {} with gamestages {}", data.fakePlayerName, data.stages);
+    }
+
+    public static PlayerDataHandler.IStageData getDataFor(final String fakePlayerName) {
+        return fakePlayerData.getOrDefault(fakePlayerName, DEFAULT);
+    }
+
+    private static final FakePlayerData DEFAULT = new FakePlayerData("DEFAULT", Collections.emptySet());
+
+    private final Set<String> stages = new HashSet<>();
+    private final String fakePlayerName;
+
+    private FakePlayerData(final String fakePlayerName, final Set<String> stages) {
+        this.stages.addAll(stages);
+        this.fakePlayerName = fakePlayerName;
+    }
+
+    @Override
+    public Collection<String> getUnlockedStages() {
+        return stages;
+    }
+
+    @Override
+    public boolean hasUnlockedStage(@Nonnull final String stage) {
+        return stages.contains(stage);
+    }
+
+    @Override
+    public boolean hasUnlockedAnyOf(final Collection<String> stages) {
+        return !Sets.intersection(this.stages, new HashSet<>(stages)).isEmpty();
+    }
+
+    @Override
+    public boolean hasUnlockedAll(final Collection<String> stages) {
+        return this.stages.containsAll(stages);
+    }
+
+    @Override
+    public void unlockStage(@Nonnull final String stage) {
+        // no op
+    }
+
+    @Override
+    public void lockStage(@Nonnull final String stage) {
+        // no op
+    }
+
+    @Override
+    public void setPlayer(@Nonnull final EntityPlayer player) {
+        // no op
+    }
+
+    @Override
+    public void clear() {
+        // no op
+    }
+
+    @Override
+    public boolean hasBeenSynced() {
+        return true;
+    }
+
+    @Override
+    public void setSynced(final boolean synced) {
+        // no op
+    }
+
+    @Nullable
+    @Override
+    public EntityPlayer getPlayer() {
+        return null;
+    }
+}

--- a/src/main/java/net/darkhax/gamestages/GameStages.java
+++ b/src/main/java/net/darkhax/gamestages/GameStages.java
@@ -1,5 +1,10 @@
 package net.darkhax.gamestages;
 
+import com.google.common.io.Files;
+import com.google.gson.GsonBuilder;
+import com.google.gson.InstanceCreator;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.reflect.TypeToken;
 import net.darkhax.bookshelf.BookshelfRegistry;
 import net.darkhax.bookshelf.command.CommandTree;
 import net.darkhax.bookshelf.lib.LoggingHelper;
@@ -20,6 +25,11 @@ import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLFingerprintViolationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.relauncher.Side;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.Level;
+
+import java.io.File;
+import java.io.IOException;
 
 @Mod(modid = "gamestages", name = "Game Stages", version = "@VERSION@", dependencies = "required-after:bookshelf@[2.2.458,);", certificateFingerprint = "@FINGERPRINT@")
 public class GameStages {
@@ -27,6 +37,7 @@ public class GameStages {
     public static final LoggingHelper LOG = new LoggingHelper("gamestages");
     public static final NetworkHandler NETWORK = new NetworkHandler("gamestages");
     public static final CommandTree COMMAND = new CommandStageTree();
+    public static File fakePlayerDataFile;
 
     // Unimplemented
     public static final GameRule GAME_RULE_SHARE_STAGES = new GameRule("shareGameStages", false);
@@ -42,6 +53,8 @@ public class GameStages {
         CapabilityManager.INSTANCE.register(IStageData.class, new Storage(), DefaultStageData::new);
         MinecraftForge.EVENT_BUS.register(new PlayerDataHandler());
         BookshelfRegistry.addCommand(COMMAND);
+        fakePlayerDataFile = new File(event.getModConfigurationDirectory(), "gameStagesFakePlayerData.json");
+        FakePlayerData.reloadFromFile();
     }
 
     @EventHandler

--- a/src/main/java/net/darkhax/gamestages/capabilities/PlayerDataHandler.java
+++ b/src/main/java/net/darkhax/gamestages/capabilities/PlayerDataHandler.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import net.darkhax.gamestages.FakePlayerData;
 import net.darkhax.gamestages.GameStages;
 import net.darkhax.gamestages.event.GameStageEvent;
 import net.darkhax.gamestages.packet.PacketRequestClientSync;
@@ -48,64 +49,11 @@ public class PlayerDataHandler {
      * @return The stage data for the player.
      */
     public static IStageData getStageData (EntityPlayer player) {
-
-        return player != null && player.hasCapability(CAPABILITY, EnumFacing.DOWN) ? player.getCapability(CAPABILITY, EnumFacing.DOWN) : player instanceof FakePlayer ? new PlayerDataHandler.IStageData() {
-            @Override
-            public Collection<String> getUnlockedStages() {
-                return Collections.emptyList();
-            }
-
-            @Override
-            public boolean hasUnlockedStage(@Nonnull final String stage) {
-                return true;
-            }
-
-            @Override
-            public boolean hasUnlockedAnyOf(final Collection<String> stages) {
-                return true;
-            }
-
-            @Override
-            public boolean hasUnlockedAll(final Collection<String> stages) {
-                return true;
-            }
-
-            @Override
-            public void unlockStage(@Nonnull final String stage) {
-                //noop
-            }
-
-            @Override
-            public void lockStage(@Nonnull final String stage) {
-                // noop
-            }
-
-            @Override
-            public void setPlayer(@Nonnull final EntityPlayer player) {
-                // noop
-            }
-
-            @Override
-            public void clear() {
-
-            }
-
-            @Override
-            public boolean hasBeenSynced() {
-                return true;
-            }
-
-            @Override
-            public void setSynced(final boolean synced) {
-                //noop
-            }
-
-            @Nullable
-            @Override
-            public EntityPlayer getPlayer() {
-                return player;
-            }
-        } : null;
+        if (player != null) {
+            if (player.hasCapability(CAPABILITY, EnumFacing.DOWN)) return player.getCapability(CAPABILITY, EnumFacing.DOWN);
+            if (player instanceof FakePlayer) return FakePlayerData.getDataFor(player.getName());
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/net/darkhax/gamestages/capabilities/PlayerDataHandler.java
+++ b/src/main/java/net/darkhax/gamestages/capabilities/PlayerDataHandler.java
@@ -25,6 +25,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.common.util.Constants.NBT;
+import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -48,7 +49,63 @@ public class PlayerDataHandler {
      */
     public static IStageData getStageData (EntityPlayer player) {
 
-        return player != null && player.hasCapability(CAPABILITY, EnumFacing.DOWN) ? player.getCapability(CAPABILITY, EnumFacing.DOWN) : null;
+        return player != null && player.hasCapability(CAPABILITY, EnumFacing.DOWN) ? player.getCapability(CAPABILITY, EnumFacing.DOWN) : player instanceof FakePlayer ? new PlayerDataHandler.IStageData() {
+            @Override
+            public Collection<String> getUnlockedStages() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public boolean hasUnlockedStage(@Nonnull final String stage) {
+                return true;
+            }
+
+            @Override
+            public boolean hasUnlockedAnyOf(final Collection<String> stages) {
+                return true;
+            }
+
+            @Override
+            public boolean hasUnlockedAll(final Collection<String> stages) {
+                return true;
+            }
+
+            @Override
+            public void unlockStage(@Nonnull final String stage) {
+                //noop
+            }
+
+            @Override
+            public void lockStage(@Nonnull final String stage) {
+                // noop
+            }
+
+            @Override
+            public void setPlayer(@Nonnull final EntityPlayer player) {
+                // noop
+            }
+
+            @Override
+            public void clear() {
+
+            }
+
+            @Override
+            public boolean hasBeenSynced() {
+                return true;
+            }
+
+            @Override
+            public void setSynced(final boolean synced) {
+                //noop
+            }
+
+            @Nullable
+            @Override
+            public EntityPlayer getPlayer() {
+                return player;
+            }
+        } : null;
     }
 
     /**
@@ -57,7 +114,7 @@ public class PlayerDataHandler {
     @SubscribeEvent
     public void attachCapabilities (AttachCapabilitiesEvent<Entity> event) {
 
-        if (event.getObject() instanceof EntityPlayer) {
+        if ((event.getObject() instanceof EntityPlayer) && !(event.getObject() instanceof FakePlayer)) {
             event.addCapability(new ResourceLocation("gamestages", "playerdata"), new Provider((EntityPlayer) event.getObject()));
         }
     }

--- a/src/main/java/net/darkhax/gamestages/commands/CommandReloadFakePlayers.java
+++ b/src/main/java/net/darkhax/gamestages/commands/CommandReloadFakePlayers.java
@@ -1,0 +1,29 @@
+package net.darkhax.gamestages.commands;
+
+import net.darkhax.bookshelf.command.Command;
+import net.darkhax.gamestages.FakePlayerData;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.server.MinecraftServer;
+
+public class CommandReloadFakePlayers extends Command {
+    @Override
+    public String getName() {
+        return "reloadfakes";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 2;
+    }
+
+    @Override
+    public String getUsage(final ICommandSender sender) {
+        return "/gamestage reloadfakes";
+    }
+
+    @Override
+    public void execute(final MinecraftServer server, final ICommandSender sender, final String[] args) throws CommandException {
+        FakePlayerData.reloadFromFile();
+    }
+}

--- a/src/main/java/net/darkhax/gamestages/commands/CommandStageTree.java
+++ b/src/main/java/net/darkhax/gamestages/commands/CommandStageTree.java
@@ -14,6 +14,7 @@ public class CommandStageTree extends CommandTree {
         this.addSubcommand(new CommandStageClear());
         this.addSubcommand(new CommandMirrorStages());
         this.addSubcommand(new CommandTransferStages());
+        this.addSubcommand(new CommandReloadFakePlayers());
     }
 
     @Override


### PR DESCRIPTION
This should mean that gamestages are much more compatible with automated
miners and such.

You could probably provide a config to whitelist specific fakeplayer ids
rather than all. The only call that won't work is "getAllStages" since
that's not a globally stored list.

This would likely address issues https://github.com/Darkosto/SevTech-Ages/issues/1733 and https://github.com/Darkosto/SevTech-Ages/issues/1803