### PR TITLE
feat: add cleared event

### DIFF
--- a/src/main/java/net/darkhax/gamestages/commands/CommandStageClear.java
+++ b/src/main/java/net/darkhax/gamestages/commands/CommandStageClear.java
@@ -4,7 +4,6 @@ import net.darkhax.bookshelf.command.Command;
 import net.darkhax.gamestages.GameStageHelper;
 import net.darkhax.gamestages.data.IStageData;
 import net.darkhax.gamestages.event.GameStageEvent;
-import net.minecraft.client.Minecraft;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;

--- a/src/main/java/net/darkhax/gamestages/commands/CommandStageClear.java
+++ b/src/main/java/net/darkhax/gamestages/commands/CommandStageClear.java
@@ -3,12 +3,15 @@ package net.darkhax.gamestages.commands;
 import net.darkhax.bookshelf.command.Command;
 import net.darkhax.gamestages.GameStageHelper;
 import net.darkhax.gamestages.data.IStageData;
+import net.darkhax.gamestages.event.GameStageEvent;
+import net.minecraft.client.Minecraft;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraftforge.common.MinecraftForge;
 
 public class CommandStageClear extends Command {
     
@@ -41,6 +44,8 @@ public class CommandStageClear extends Command {
             
             stageInfo.clear();
             GameStageHelper.syncPlayer(player);
+
+            MinecraftForge.EVENT_BUS.post(new GameStageEvent.Cleared(player, stageInfo));
             
             player.sendMessage(new TextComponentTranslation("commands.gamestage.clear.target", stageCount));
             

--- a/src/main/java/net/darkhax/gamestages/event/GameStageEvent.java
+++ b/src/main/java/net/darkhax/gamestages/event/GameStageEvent.java
@@ -1,5 +1,6 @@
 package net.darkhax.gamestages.event;
 
+import net.darkhax.gamestages.data.IStageData;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
@@ -88,6 +89,23 @@ public class GameStageEvent extends PlayerEvent {
         public Removed (EntityPlayer player, String stageName) {
             
             super(player, stageName);
+        }
+    }
+
+    /**
+     * This event is fired after the stages have been cleared from a player.
+     */
+    public static class Cleared extends PlayerEvent {
+        private IStageData stageData;
+
+        public Cleared (EntityPlayer player, IStageData stageData) {
+            super(player);
+
+            this.stageData = stageData;
+        }
+
+        public IStageData getStageData() {
+            return stageData;
         }
     }
     


### PR DESCRIPTION
Was needing this event for a Scoreboard addition to SevTweaks. And thought would be easier to PR this. 

- Not sure if we wanted more data on the event. The player and the old stage data would be enough I guess? I only care for the player however. But not sure is the getter should be changed to "oldData" or something so it shows that it's not valid anymore/old.

But feel free to take a poke and suggest changes etc.. 😄 
