### PR TITLE
feat: add config for debug logging

### DIFF
--- a/src/main/java/net/darkhax/gamestages/GameStageHelper.java
+++ b/src/main/java/net/darkhax/gamestages/GameStageHelper.java
@@ -3,6 +3,7 @@ package net.darkhax.gamestages;
 import java.util.Arrays;
 import java.util.Collection;
 
+import net.darkhax.gamestages.config.Configuration;
 import net.darkhax.gamestages.data.GameStageSaveHandler;
 import net.darkhax.gamestages.data.IStageData;
 import net.darkhax.gamestages.event.GameStageEvent;
@@ -287,7 +288,9 @@ public class GameStageHelper {
     public static void syncPlayer (EntityPlayerMP player) {
         
         final IStageData info = GameStageHelper.getPlayerData(player);
-        GameStages.LOG.info("Syncing {} stages for {}.", info.getStages().size(), player.getName());
+        if (Configuration.debug.logDebug) {
+            GameStages.LOG.info("Syncing {} stages for {}.", info.getStages().size(), player.getName());
+        }
         GameStages.NETWORK.sendTo(new PacketSyncClient(info.getStages()), player);
     }
 }

--- a/src/main/java/net/darkhax/gamestages/config/Configuration.java
+++ b/src/main/java/net/darkhax/gamestages/config/Configuration.java
@@ -1,0 +1,27 @@
+package net.darkhax.gamestages.config;
+
+import net.minecraftforge.common.config.Config;
+import net.minecraftforge.common.config.ConfigManager;
+import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@EventBusSubscriber
+@Config(modid = "gamestages")
+public class Configuration {
+    public static Debug debug = new Debug();
+
+    @SubscribeEvent
+    public static void onConfigChangedEvent(ConfigChangedEvent.OnConfigChangedEvent event) {
+        if (!event.getModID().equalsIgnoreCase("gamestages")) {
+            return;
+        }
+        ConfigManager.sync("gamestages", Config.Type.INSTANCE);
+    }
+
+    public static class Debug {
+        @Config.Comment("Debug logging for any kind of syncing or changes to a players stage.")
+        @Config.Name("Log Debug Data")
+        public boolean logDebug = true;
+    }
+}

--- a/src/main/java/net/darkhax/gamestages/data/GameStageSaveHandler.java
+++ b/src/main/java/net/darkhax/gamestages/data/GameStageSaveHandler.java
@@ -18,6 +18,7 @@ import com.google.gson.Gson;
 import net.darkhax.bookshelf.util.NBTUtils;
 import net.darkhax.gamestages.GameStageHelper;
 import net.darkhax.gamestages.GameStages;
+import net.darkhax.gamestages.config.Configuration;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
@@ -76,7 +77,9 @@ public class GameStageSaveHandler {
                 
                 final NBTTagCompound tag = CompressedStreamTools.read(playerFile);
                 playerData.readFromNBT(tag);
-                GameStages.LOG.info("Loaded {} stages for {}.", playerData.getStages().size(), event.getEntityPlayer().getName());
+                if (Configuration.debug.logDebug) {
+                    GameStages.LOG.info("Loaded {} stages for {}.", playerData.getStages().size(), event.getEntityPlayer().getName());
+                }
             }
             
             catch (final IOException e) {
@@ -111,7 +114,9 @@ public class GameStageSaveHandler {
                 try {
                     
                     CompressedStreamTools.write(tag, playerFile);
-                    GameStages.LOG.info("Saved {} stages for {}.", playerData.getStages().size(), event.getEntityPlayer().getName());
+                    if (Configuration.debug.logDebug) {
+                        GameStages.LOG.info("Saved {} stages for {}.", playerData.getStages().size(), event.getEntityPlayer().getName());
+                    }
                 }
                 
                 catch (final IOException e) {
@@ -232,8 +237,9 @@ public class GameStageSaveHandler {
      * Reloads fake player data from the fake player json file.
      */
     public static void reloadFakePlayers () {
-        
-        GameStages.LOG.info("Reloading fakeplayers stage data from {}.", FAKE_PLAYER_STAGE_FILE.getName());
+        if (Configuration.debug.logDebug) {
+            GameStages.LOG.info("Reloading fakeplayers stage data from {}.", FAKE_PLAYER_STAGE_FILE.getName());
+        }
         
         FAKE_STAGE_DATA.clear();
         
@@ -262,7 +268,9 @@ public class GameStageSaveHandler {
     private static void addFakePlayer (FakePlayerData data) {
         
         FAKE_STAGE_DATA.put(data.getFakePlayerName(), data);
-        GameStages.LOG.info("Adding fakeplayer {} with gamestages {}", data.getFakePlayerName(), data.getStages());
+        if (Configuration.debug.logDebug) {
+            GameStages.LOG.info("Adding fakeplayer {} with gamestages {}", data.getFakePlayerName(), data.getStages());
+        }
     }
     
     /**


### PR DESCRIPTION
- The logging is not ideal on large servers, nor worlds.
- It's useful to have hence why it's true by default but having a config would be beneficial for those who don't want to the extra console spam.

_Using the Forge Config as the new is really nice and also adds support in game for the config GUI along with the syncing of the file etc..._