### PR TITLE
refactor: change add fake method to be public

### DIFF
--- a/src/main/java/net/darkhax/gamestages/data/GameStageSaveHandler.java
+++ b/src/main/java/net/darkhax/gamestages/data/GameStageSaveHandler.java
@@ -283,6 +283,16 @@ public class GameStageSaveHandler {
             GameStages.LOG.catching(e);
         }
     }
+
+    /**
+     * Checks if the fake player is in the fake stage map.
+     *
+     * @param fakePlayerName The fake player name to check for.
+     */
+    public static boolean hasFakePlayer(String fakePlayerName) {
+
+        return FAKE_STAGE_DATA.containsKey(fakePlayerName);
+    }
     
     /**
      * Adds fake player data to the fake stage map.

--- a/src/main/java/net/darkhax/gamestages/data/GameStageSaveHandler.java
+++ b/src/main/java/net/darkhax/gamestages/data/GameStageSaveHandler.java
@@ -310,13 +310,13 @@ public class GameStageSaveHandler {
     /**
      * Removes fake player data to the fake stage map.
      *
-     * @param data The fake player data to take into account.
+     * @param fakePlayerName The fake player name to remove.
      */
-    public static void removeFakePlayer (FakePlayerData data) {
+    public static void removeFakePlayer (String fakePlayerName) {
 
-        FakePlayerData removedData = FAKE_STAGE_DATA.remove(data.getFakePlayerName());
+        FakePlayerData removedData = FAKE_STAGE_DATA.remove(fakePlayerName);
         if (removedData != null && Configuration.debug.logDebug) {
-            GameStages.LOG.info("Removing fakeplayer {} with gamestages {}", data.getFakePlayerName(), data.getStages());
+            GameStages.LOG.info("Removing fakeplayer {} with gamestages {}", fakePlayerName, removedData.getStages());
         }
     }
     

--- a/src/main/java/net/darkhax/gamestages/data/GameStageSaveHandler.java
+++ b/src/main/java/net/darkhax/gamestages/data/GameStageSaveHandler.java
@@ -289,7 +289,7 @@ public class GameStageSaveHandler {
      *
      * @param data The fake player data to take into account.
      */
-    private static void addFakePlayer (FakePlayerData data) {
+    public static void addFakePlayer (FakePlayerData data) {
         
         FAKE_STAGE_DATA.put(data.getFakePlayerName(), data);
         if (Configuration.debug.logDebug) {

--- a/src/main/java/net/darkhax/gamestages/data/GameStageSaveHandler.java
+++ b/src/main/java/net/darkhax/gamestages/data/GameStageSaveHandler.java
@@ -296,6 +296,19 @@ public class GameStageSaveHandler {
             GameStages.LOG.info("Adding fakeplayer {} with gamestages {}", data.getFakePlayerName(), data.getStages());
         }
     }
+
+    /**
+     * Removes fake player data to the fake stage map.
+     *
+     * @param data The fake player data to take into account.
+     */
+    public static void removeFakePlayer (FakePlayerData data) {
+
+        FakePlayerData removedData = FAKE_STAGE_DATA.remove(data.getFakePlayerName());
+        if (removedData != null && Configuration.debug.logDebug) {
+            GameStages.LOG.info("Removing fakeplayer {} with gamestages {}", data.getFakePlayerName(), data.getStages());
+        }
+    }
     
     /**
      * Gets data for a fake player. Real players should use {@link #getPlayerData(String)}.


### PR DESCRIPTION
Would like this to be public to allow me to add FakePlayers on the fly from mods which use dynamic names for their name generation.

- Also, add a method to remove a fake player also.
- Also, add a method to check if faker player already staged.